### PR TITLE
Nullcheck multiverse world handles

### DIFF
--- a/src/main/java/net/rymate/bchatmanager/bChatManager.java
+++ b/src/main/java/net/rymate/bchatmanager/bChatManager.java
@@ -108,8 +108,11 @@ public class bChatManager extends JavaPlugin {
             format = format.replaceAll("%faction", "");
         }
 
+        MultiverseWorld mvWorld = null;
         if (mv) {
-            MultiverseWorld mvWorld = core.getMVWorldManager().getMVWorld(player.getWorld());
+            mvWorld = core.getMVWorldManager().getMVWorld(player.getWorld());
+        }
+        if (mvWorld != null) {
             format = format.replaceAll("%mvworld", mvWorld.getColoredWorldString());
         } else {
             format = format.replaceAll("%mvworld", "");


### PR DESCRIPTION
This happens on some setups where plugins create worlds that are not managed by multiverse, this change fixes it and defaults the mvworld to empty string for said worlds.
