### PR TITLE
squid:S3052, squid:UselessParenthesesCheck - Fields should not be ini…

### DIFF
--- a/src/main/java/net/rymate/bchatmanager/bChatListener.java
+++ b/src/main/java/net/rymate/bchatmanager/bChatListener.java
@@ -22,7 +22,7 @@ public class bChatListener implements Listener {
     public String LOCAL_MESSAGE_FORMAT = "[LOCAL] %prefix %player: &f%message";
     public String PERSONAL_MESSAGE_FORMAT = "[MSG] [%player -> %reciever] &f%message";
     public String OP_MESSAGE_FORMAT = "&c[OPS ONLY] %player: &f%message";
-    public Boolean RANGED_MODE = false;
+    public Boolean RANGED_MODE;
     public Boolean SPECIAL_FEATURES = true;
     public double CHAT_RANGE = 100d;
     private final bChatManager plugin;

--- a/src/main/java/net/rymate/bchatmanager/bChatManager.java
+++ b/src/main/java/net/rymate/bchatmanager/bChatManager.java
@@ -33,10 +33,10 @@ import java.util.List;
  */
 public class bChatManager extends JavaPlugin {
 
-    public static Chat chat = null;
+    public static Chat chat;
     private bChatListener listener;
     private YamlConfiguration config;
-    private boolean factions = false;
+    private boolean factions;
     private boolean mv;
     private MultiverseCore core;
     private PluginCommand meCmd;
@@ -104,7 +104,7 @@ public class bChatManager extends JavaPlugin {
             chat = chatProvider.getProvider();
         }
 
-        return (chat != null);
+        return chat != null;
     }
 
     @Override
@@ -247,7 +247,7 @@ public class bChatManager extends JavaPlugin {
             return true;
         }
 
-        if ((command.getName().equals("bchatreload"))) {
+        if (command.getName().equals("bchatreload")) {
             if (!(sender instanceof Player)) {
                 setupConfig();
                 listener.reloadConfig();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S3052 - Fields should not be initialized to default values
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052
https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

M-Ezzat